### PR TITLE
Revert "averageAttack option, swarm can now attack with advantage or disadvantage"

### DIFF
--- a/swarmRoller.py
+++ b/swarmRoller.py
@@ -14,11 +14,10 @@ print 'Hit Points per swarm individual? (examples: "7", "500")'
 print 'Number of members of swarm? (examples: "2", "100")'
 """
 class Swarm(object):
-	def __init__(self, name, attackBonus, damageDice, averageDamage, hitPoints, size):
+	def __init__(self, name, attackBonus, damageDice, hitPoints, size):
 		self.name = name
 		self.attackBonus = attackBonus
 		self.damageDice = damageDice
-		self.averageDamage = averageDamage
 		self.individualHP = hitPoints
 		self.size = size
 
@@ -57,10 +56,6 @@ def collectSwarmFromFile(fileName):
 		damageDice = fileList[2]
 		print 'Swarm dice are: ' + damageDice
 
-		averageDamage = 0
-		averageDamage = calcAverageDamage(damageDice)
-		print 'Swarm average damage is: ' + str(averageDamage)
-
 		hitPoints = 0
 		hitPoints += int(fileList[3])
 		print 'Hit Points per swarm individual: ' + str(hitPoints)
@@ -69,25 +64,11 @@ def collectSwarmFromFile(fileName):
 		size += int(fileList[4])
 		print 'Number of members of swarm: ' + str(size) + '\n'
 
-		return Swarm(name, attackBonus, damageDice, averageDamage, hitPoints, size)
-
-
+		return Swarm(name, attackBonus, damageDice, hitPoints, size)
 
 def swarmAttack(swarmIn):
 	print 'AC of target? (examples: "5", "20")'
 	targetAC = int(raw_input())
-
-	print 'Do you want to do average damage? (y/n)'
-	isAverageAttack = (raw_input() == 'y')
-
-	isAdvantaged = False
-	isDisadvantaged = False
-	print 'Is the swarm advantaged or disadvantaged? (adv/dis/no)'
-	input = raw_input()
-	if (input == 'adv'):
-		isAdvantaged = True
-	elif (input == 'dis'):
-		isDisadvantaged = True
 
 	damage = 0
 	# dice info below for calculations
@@ -96,38 +77,20 @@ def swarmAttack(swarmIn):
 	diceDamageModifier = int(swarmIn.damageDice[endOfDiceType + 1:])
 	
 	for i in range(swarmIn.currentNumMembers):
-		attackRoll = 0
-		if isAdvantaged:
-			attackRoll1 = dice.roll('1d20t') + swarmIn.attackBonus
-			attackRoll2 = dice.roll('1d20t') + swarmIn.attackBonus
-			attackRoll = max(attackRoll1, attackRoll2)
-		elif isDisadvantaged:
-			attackRoll1 = dice.roll('1d20t') + swarmIn.attackBonus
-			attackRoll2 = dice.roll('1d20t') + swarmIn.attackBonus
-			attackRoll = min(attackRoll1, attackRoll2)
-		else:
-			attackRoll = dice.roll('1d20t') + swarmIn.attackBonus
+		attackRoll = dice.roll('1d20t') + swarmIn.attackBonus
 		
 		# critical hits always hit, and deal twice the damage dice
 		if (attackRoll - swarmIn.attackBonus) == 20:
-			if isAverageAttack:
-				damage += ((swarmIn.averageDamage * 2) - diceDamageModifier)
-			else:
-				dCharPosition = diceType.find('d')
-				numDice = int(diceType[:dCharPosition])
-				numDice *= 2
-				tempDiceType = str(numDice) + diceType[dCharPosition:]
-				rollTotal = dice.roll(tempDiceType + 't') + diceDamageModifier
-				damage += rollTotal
+			dCharPosition = diceType.find('d')
+			numDice = int(diceType[:dCharPosition])
+			numDice *= 2
+			tempDiceType = str(numDice) + diceType[dCharPosition:]
+			rollTotal = dice.roll(tempDiceType + 't') + diceDamageModifier
+			damage += rollTotal
 
 		elif attackRoll >= targetAC:
-			if isAverageAttack:
-				damage += swarmIn.averageDamage
-			else:
-				rollTotal = dice.roll(diceType + 't') + diceDamageModifier
-				damage += rollTotal
-		
-
+			rollTotal = dice.roll(diceType + 't') + diceDamageModifier
+			damage += rollTotal
 	# TODO: calculating average damage as well for convenience
 	"""
 	numDice = diceType[:diceType.find('d')]
@@ -140,21 +103,9 @@ diceDamageModifier
 	print 'Approximate average damage: ' + \
 str(int((chanceOfHitting * averageDamageRoll) * swarmIn.currentNumMembers))
 	"""	
-	if damage == 0:
-		print 'The attack missed!\n'
-	else:
-		print 'The swarm deals ' + str(damage) + 'HP damage to the target!\n'
 
-def calcAverageDamage(damageDice):
-	dCharPosition = damageDice.find('d')
-	endPos = damageDice.find('+')
-	diceTypeAndNum = damageDice[:endPos]
-	attackBonus = int(damageDice[endPos:])
-	maxVal = float(diceTypeAndNum[dCharPosition + 1:])
-	numDice = int(damageDice[:dCharPosition])
-	average = floor((maxVal + 1) / 2) * numDice
-	avgDmg = int(average) + attackBonus
-	return avgDmg
+	print 'The swarm deals ' + str(damage) + 'HP damage to the target!\n'
+		
 
 def swarmTakesDamage(swarmIn):
 	print 'How much HP damage does the swarm take?'
@@ -185,3 +136,5 @@ while True:
 		exit()
 	else:
 		print 'Invalid option selected\n'
+
+	


### PR DESCRIPTION
Reverts keanfreeman/swarm-roller-dnd-5e#2

The new changes re-prompts the user for advantage/disadvantage and whether or not they would like to use the average damage or not. I think the functionality is good, but it should be doable without re-prompting.